### PR TITLE
Add: #91 Support Cyr(utf-8) in iTerm2

### DIFF
--- a/osx/settings/iterm2/.zshrc
+++ b/osx/settings/iterm2/.zshrc
@@ -1,0 +1,2 @@
+# 2023-03-23 11:19
+export LC_ALL='en_US.UTF-8'


### PR DESCRIPTION
# UTF-8

## Дополнительно включено в `~/.zshrc`

> `2024-09-18_1028`

```env
export LANG=en_US.UTF-8
```